### PR TITLE
Lock Python version at 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
Running Celery application on Python 3.7 cause an error:

![default](https://user-images.githubusercontent.com/30570/42284515-6c16082e-7fb5-11e8-9ae4-c080d098510c.png)

Should be fixed later.